### PR TITLE
Fix, features & improvements

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -105,6 +105,11 @@
         >
         </html:input>
       </hbox>
+      <checkbox
+        native="false"
+        data-l10n-id="slash-as-subfolder-delimiter"
+        preference="extensions.zotero.__addonRef__.slashAsSubfolderDelimiter"
+      />
 
       <separator class="thin" />
 

--- a/addon/locale/de/addon.ftl
+++ b/addon/locale/de/addon.ftl
@@ -1,0 +1,9 @@
+attachment-manager = Anhang-Manager
+attach-new-file = Neue Datei anhängen
+rename-move-attachment = Anhang umbenennen und verschieben
+match-attachment = Anhang zuordnen
+rename-attachment = Anhang umbenennen
+move-attachment = Anhang verschieben
+restore-pdf-annotation = PDF-Anmerkung wiederherstellen
+open-using = Öffnen mit
+choose-other-app = Andere App auswählen

--- a/addon/locale/de/preferences.ftl
+++ b/addon/locale/de/preferences.ftl
@@ -1,0 +1,51 @@
+directory = Stammverzeichnis:
+choose-dir =
+    .label = Auswählen...
+setting = Einstellungen
+
+source-title = Quellpfad
+source-intro = &lt;Neue Datei anhängen&gt; ruft die zuletzt hinzugefügte Datei aus diesem Verzeichnis ab und hängt sie an das Zotero-Element/die Zotero-Sammlung an.
+
+read-pdf-title = Titel aus PDF-Datei lesen:
+readPDFtitle-never =
+    .label = Nie
+readPDFtitle-nonCJK =
+    .label = Außer für CJK
+readPDFtitle-always =
+    .label = Immer
+
+attach-title = Anhangtyp
+attach-intro = Wenn Sie die offizielle Zotero- oder WebDAV-Synchronisierung verwenden, wählen Sie &lt;Gespeicherte Kopie&gt;. Wenn Sie eine Drittanbieter-Synchronisierung wie Nutstore, OneDrive usw. verwenden, wählen Sie &lt;Link&gt; und konfigurieren Sie den &lt;Zielpfad&gt; ordnungsgemäß. Dateien werden in den Zielpfad verschoben und dann als Link-Anhang in Zotero importiert.
+attach-type-start = Datei anhängen
+attach-type-end = an das Zotero-Element/die Zotero-Sammlung
+importing =
+    .label = Gespeicherte Kopie
+linking =
+    .label = Link
+
+dest-title = Zielpfad
+dest-intro = &lt;Anhang verschieben&gt; verschiebt den Anhang in diesen Pfad, und der endgültige Dateipfad lautet &lt;Stammverzeichnis/Unterverzeichnis/Dateiname&gt;. Lassen Sie dieses Feld leer, wenn kein &lt;Unterverzeichnis&gt; benötigt wird.
+subfolder = Unterverzeichnis:
+
+slash-as-subfolder-delimiter =
+    .label = Schrägstriche (/) in Variablen als Unterverzeichnis-Trennzeichen interpretieren
+
+filename = Dateiname:
+
+other-title = Andere Einstellungen
+auto-rename =
+    .label = Hinzugefügte Anhänge automatisch umbenennen
+auto-move =
+    .label = Hinzugefügte Anhänge automatisch verschieben
+auto-remove-empty-folder =
+    .label = Leere Ordner nach dem Verschieben automatisch löschen
+file-types = Arten von Anhängen zur Umbenennung/Verschiebung
+
+about-title = Über Attanger
+about-intro = 🌠 Frohes Neues Jahr! Attanger ist eine Abkürzung für Attachment Manager, und dieses Projekt bezieht sich stark auf das ZotFile-Plugin der Zotero-Version 6.
+
+
+preferences-file-renaming-customize-button =
+    .label = Dateinamenformat anpassen...
+
+preferences-file-renaming-format-instructions-more = Weitere Informationen finden Sie in der <label data-l10n-name="file-renaming-format-help-link">Dokumentation</label>.

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -4,5 +4,6 @@ rename-move-attachment = Rename and Move Attachment
 match-attachment = Match Attachment
 rename-attachment = Rename Attachment
 move-attachment = Move Attachment
+restore-pdf-annotation = Restore PDF Annotation
 open-using = Open Using
 choose-other-app = Choose Other App

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -27,6 +27,9 @@ dest-title = Destination Path
 dest-intro = &lt;Move Attachment&gt; will move the attachment to this path, and the final file path will be &lt;Root Directory/Subfolder/Filename&gt;. Leave blank if no &lt;Subfolder&gt; is needed.
 subfolder = Subfolder:
 
+slash-as-subfolder-delimiter =
+    .label = Parse forward slashes (/) in variables as subfolder delimiters
+
 filename = Filename:
 
 other-title = Other Settings

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -1,7 +1,9 @@
 attachment-manager = Attachment Manager
 attach-new-file = Allega nuovo file
 rename-move-attachment = Rinomina e sposta allegato
+match-attachment = Abbina allegato
 rename-attachment = Rinomina allegato
 move-attachment = Sposta allegato
+restore-pdf-annotation = Ripristina annotazione PDF
 open-using = Apri con
 choose-other-app = Scegli altra app

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -19,6 +19,9 @@ dest-title = Percorso di destinazione
 dest-intro = &lt;Sposta allegato&gt; sposterà l'allegato in questo percorso e il percorso finale sarà &lt;Directory di base/Sottocartella/Nome file&gt;. Lasciare vuoto se non è richiesta alcuna &lt;Sottocartella&gt;.
 subfolder = Sottocartella:
 
+slash-as-subfolder-delimiter =
+    .label = Interpretare le barre (/) nelle variabili come delimitatori di sottocartelle
+
 filename = Filename:
 
 other-title = Altre impostazioni

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -4,5 +4,6 @@ rename-move-attachment = 重命名并移动附件
 match-attachment = 匹配附件
 rename-attachment = 重命名附件
 move-attachment = 移动附件
+restore-pdf-annotation = 恢复PDF标注
 open-using = 打开方式
 choose-other-app = 选择其它应用

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -27,6 +27,9 @@ dest-title = 靶路径
 dest-intro = <移动附件> 会将附件移动到该路径下，文件最终路径为 <根目录/子目录/文件名>。若无需 <子目录> 留空即可。
 subfolder = 子目录:
 
+slash-as-subfolder-delimiter =
+    .label = 将变量中的正斜杠 (/) 解析为子文件夹分隔符
+
 filename = 文件名:
 
 other-title = 其他设置

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -2,6 +2,7 @@
 pref("extensions.zotero.__addonRef__.enable", true);
 pref("extensions.zotero.__addonRef__.attachType", "linking");
 pref("extensions.zotero.__addonRef__.subfolderFormat", `{{collection}}`);
+pref("extensions.zotero.__addonRef__.slashAsSubfolderDelimiter", false);
 pref("extensions.zotero.__addonRef__.sourceDir", "");
 pref("extensions.zotero.__addonRef__.readPdfTitle", "nonCJK");
 pref("extensions.zotero.__addonRef__.destDir", "");

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -833,12 +833,17 @@ async function removeEmptyFolder(path: string | nsIFile) {
     return false;
   }
   const files = folder.directoryEntries;
+  let fileCount = 0;
   while (files.hasMoreElements()) {
     const f = files.getNext().QueryInterface(Components.interfaces.nsIFile);
+    fileCount++;
     if (f.leafName !== ".DS_Store" && f.leafName !== "Thumbs.db") {
       return true;
+    } else if (fileCount > 1) {
+      break;
     }
   }
+  ztoolkit.log("Remove empty folder: ", folder.path);
   removeFile(folder, true);
   return await removeEmptyFolder(PathUtils.parent(folder.path) as string);
 }


### PR DESCRIPTION
1. **improvement**: Also automatically remove empty-like folders containing only `.DS_Store` or `Thumbs.db`.
2. **feature**: Add a checkbox in the preferences to configure whether to treat slashes `/` as subfolder delimiters. This feature introduced in [#13](https://github.com/MuiseDestiny/zotero-attanger/issues/13) is inappropriate for some cases; for instance, _IEEE/ACM Transactions on Networking_ should not be split into subfolders.
3. **locale**: Add German translation.
4. **fix**: Fix the failure of moving files due to `PathUtils.join` being unable to join a path with another relative path.

---

1. **改进**: 自动移除仅包含 `.DS_Store` 或 `Thumbs.db` 的空文件夹。
2. **功能**: 添加一个配置选项，用于选择是否将项目字段中的斜杠 `/` 视为子文件夹分隔符。由于 [#13](https://github.com/MuiseDestiny/zotero-attanger/issues/13) 引入的这个新特性对部分用户并不合适，例如期刊《IEEE/ACM Transactions on Networking》不应当被切分。
3. **本地化**: 添加德语翻译。
4. **修复**: 修正由于 `PathUtils.join` 无法将一个路径与另一个相对路径拼接导致的文件移动失败。