### PR TITLE
add menu `Match Attanger Attachment`

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -504,24 +504,29 @@ async function matchAttangerAttachment() {
     const attachmentBaseName = Zotero.Attachments.getFileBaseNameFromItem(item);
 
     ztoolkit.log('item: ', item.getDisplayTitle());
-    ztoolkit.log('  realRoot:', realRoot);
-    ztoolkit.log('  exist attachments:', existAttachments);
+    ztoolkit.log('|  realRoot:', realRoot);
+    ztoolkit.log('|  exist attachments:', existAttachments);
 
     for (const ext of fileTypeList) {
       const fullpath = PathUtils.joinRelative(realRoot, `${attachmentBaseName}.${ext}`)
       const file = Zotero.File.pathToFile(fullpath);
+      const basename = file.leafName
       // Check if the file exists before attempting to import
       if (file.exists()) {
-        try {
-          const attItem = await Zotero.Attachments.importFromFile({
-            file: fullpath,
-            libraryID: item.libraryID,
-            parentItemID: item.id,
-          });
-          showAttachmentItem(attItem);
-          ztoolkit.log('Imported attachment:', attItem.getDisplayTitle());
-        } catch (error) {
-          ztoolkit.log('Error importing attachment:', error);
+        if (!existAttachments.includes(basename)) {
+          try {
+            const attItem = await Zotero.Attachments.importFromFile({
+              file: fullpath,
+              libraryID: item.libraryID,
+              parentItemID: item.id,
+            });
+            showAttachmentItem(attItem);
+            ztoolkit.log('|  Imported attachment:', attItem.getDisplayTitle());
+          } catch (error) {
+            ztoolkit.log('|  Error importing attachment:', error);
+          }
+        } else {
+          ztoolkit.log('|  skip exists:', basename);
         }
       }
     }


### PR DESCRIPTION
在Item的右键菜单上增加了一个新的选项`Match Attanger Attachment`, 它与原来的`Match Attachment`的区别为
* `Match Attachment`: 在`Source Path`目录下(不包括子目录)搜索所有的`.pdf`和`.caj`文件，然后对于所有选中的Item, 使用匹配文件名和标题(计算字符距离)的方法，匹配并添加某个文件作为附件。这种方法适合添加其他来源的文件。
* `Match Attanger Attachment`: 对于所选的条目，计算attanger进行rename之后的文件名，然后到`SourcePath`/`subfolderPath`/`AttangerRename.ext`, 其中ext为配置项`Types of Attachments for Renaming/Moving`中的所有。如果存在这个文件，且这个文件还没有作为Item的Attachment, 则进行添加。

## 什么场景需要这个选项
为了解释这个需求，我们首先来分析以下我们日常使用zotero-attanger的场景
* 同步`My Library`中的文件: 我们设置 `Destination Path`是为了更加方便的管理zotero附件。我们可以把附件文件夹通过`nextcloud`等私有或者其他商业云盘进行同步，仅使用zotero的账户来同步Item元数据。这样在另外一台机器上，我们在登录zotero同步元数据之后，只需要设置zotero的`Linked Attachment Base Directory` 即可直接使用同步过来的附件了。
* 但是对于`Group Library`, 这样做就不行了，因为[Group Library不支持Linked File](https://www.zotero.org/support/attaching_files), 于是我们使用以下方法来实现等效的附件同步
  * 在zotero设置中，取消所有文件同步选项(Sync->File Syncing), 我们使用额外的云盘直接同步zotero-attanger的`Destination Path`
  * 设置zotero-attanger的`Source Path`和`Destination Path`，还有zotero的`Linked Attachment Base Directory`为同一目录，并在云盘服务中共享这个文件夹
  * 在`My Library`中创建与`Group Library`同名的collection(和subcollection结构)
  * 日常直接添加item到`My Library`中的这个collection中，zotero-attanger会自动管理附件信息，并写入`Destination Path`中
  * 把`My Library`中的这个collection中的Item，复制到对应的`Group Library`中, 我们使用group来同步Item的元数据
  * 在另外一台电脑上
    * 配置共享云同步文件夹，设置zotero-attanger的`Source Path`和`Destination Path`，还有zotero的`Linked Attachment Base Directory`都为此文件夹。 
    * 使用其他组成员的zotero帐号同步`Group Library`, 他需要在他的`My Library`中手动建立与`Group Library`同名的collection和subcollections结构。并从`Group Library`中手动复制条目，这时复制过来的条目是不包含附件信息的
    * 选中所有缺少附件的Item, 右键，使用我们这个补丁实现的`Match Attanger Attachment`，更新附件信息
    * 至此，我们实现了等效的`Group Library`的附件同步

## 总结
`Match Attanger Attachment`是为了直接添加由zotero-attanger自己生成的附件，可以用来辅助实现等效的`Group Library`的附件文件同步