### PR TITLE
Modified the "rename-move-attachment" in menu.ts file

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -23,17 +23,25 @@ export default class Menu {
             const attItems = [];
             for (const item of items) {
               if (
-                item.isImportedAttachment() &&
+                item.isAttachment() &&
                 (await item.fileExists())
               ) {
-                await Zotero.RecognizeDocument.recognizeItems([item]);
+                if (item.isImportedAttachment()) {
+                  await Zotero.RecognizeDocument.recognizeItems([item]);
+                }
                 attItems.push(item);
               }
               if (item.isTopLevelItem() && item.isRegularItem()) {
                 // 等待是否有新增附件
                 await Zotero.Promise.delay(1000);
                 for (const id of item.getAttachments()) {
-                  attItems.push(Zotero.Items.get(id));
+                  const att = Zotero.Items.get(id);
+                  if (
+                    att.isAttachment() &&
+                    (await att.fileExists())
+                  ) {
+                    attItems.push(att);
+                  }
                 }
               }
             }
@@ -49,15 +57,15 @@ export default class Menu {
                     showAttachmentItem(att);
                     return;
                   }
-                  if (canProcess && Zotero.Prefs.get("autoRenameFiles")) {
-                    await renameFile(att);
-                  }
                   if (
                     canProcess &&
                     getPref("autoMove") &&
                     getPref("attachType") == "linking"
                   ) {
                     att = (await moveFile(att)) as Zotero.Item;
+                  }
+                  if (canProcess && Zotero.Prefs.get("autoRenameFiles")) {
+                    await renameFile(att);
                   }
                 } catch (e) {
                   ztoolkit.log(e);
@@ -114,8 +122,8 @@ export default class Menu {
             selectedCollection = ZoteroPane.getSelectedCollection()
             for (const item of getAttachmentItems(false)) {
               try {
-                const attItem = (await renameFile(item)) as Zotero.Item;
-                attItem && (await moveFile(attItem));
+                const attItem = await moveFile(item) as Zotero.Item;
+                attItem && ((await renameFile(attItem)));
                 attItem && showAttachmentItem(attItem);
               } catch (e) {
                 ztoolkit.log(e);
@@ -900,7 +908,7 @@ export async function moveFile(attItem: any) {
   // await Zotero.File.createDirectoryIfMissingAsync(destDir);
   // 移动文件到目标文件夹
   try {
-    await IOUtils.move(sourcePath, destPath);
+    await IOUtils.copy(sourcePath, destPath);
   } catch (e) {
     ztoolkit.log(e);
     return await moveFile(attItem);
@@ -916,7 +924,7 @@ export async function moveFile(attItem: any) {
   window.setTimeout(async () => {
     // 迁移标注
     await transferItem(attItem, newAttItem);
-    removeEmptyFolder(PathUtils.parent(sourcePath) as string);
+    // removeEmptyFolder(PathUtils.parent(sourcePath) as string);
     await attItem.eraseTx();
   });
   return newAttItem;


### PR DESCRIPTION
Firstly, a bug was fixed where the `rename` and `move` functions of files as attachments could not be triggered when manually adding linked files as attachments. The reason was that `attItems.push()` was written within the condition of `item.isImportedAttachment()`. See the issue [#276](https://github.com/MuiseDestiny/zotero-attanger/issues/276) submitted by me.

Secondly, the order of `moveFile()` and `renameFile()` was swapped to prevent `Attanger` from directly operating on the original folder.

Finally, the moving operation in `moveFile()` was modified to a copying operation to ensure that `Attanger` has the ability to read but not write in the original file path. See the issue [#274](https://github.com/MuiseDestiny/zotero-attanger/issues/274) submitted by me.