### PR TITLE
fix: handle Windows mount-point target directories

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -727,7 +727,9 @@ async function renameFile(attItem: Zotero.Item, retry = 0) {
   if (!parentItemID) { return attItem }
   const parentItem = await Zotero.Items.getAsync(parentItemID);
   // getFileBaseNameFromItem
-  let newName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, { attachmentTitle: attItem.getField("title") as string });
+  let newName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, {
+    attachmentTitle: attItem.getField("title") as string,
+  } as any);
 
   const origFilename = PathUtils.split(file).pop() as string;
   const ext = origFilename.match(filenameExtRE);
@@ -827,7 +829,7 @@ export async function moveFile(attItem: any) {
   const filename = PathUtils.filename(sourcePath);
   let destPath = PathUtils.joinRelative(destDir, filename);
   if (sourcePath == destPath) return;
-  if (await IOUtils.exists(destPath)) {
+  if (await pathExists(destPath)) {
     ztoolkit.log("目标目录存在", file2md5(sourcePath), file2md5(destPath));
     if (file2md5(sourcePath) != file2md5(destPath)) {
       ztoolkit.log("不是同一个文件");
@@ -884,10 +886,10 @@ export async function moveFile(attItem: any) {
     }
   }
   // 创建中间路径
-  if (!(await IOUtils.exists(destDir))) {
+  if (!(await pathExists(destDir, "directory"))) {
     const create = [destDir];
     let parent = PathUtils.parent(destDir);
-    while (parent && !(await IOUtils.exists(parent))) {
+    while (parent && !(await pathExists(parent, "directory"))) {
       create.push(parent);
       parent = PathUtils.parent(parent);
     }
@@ -900,7 +902,7 @@ export async function moveFile(attItem: any) {
   // await Zotero.File.createDirectoryIfMissingAsync(destDir);
   // 移动文件到目标文件夹
   try {
-    await IOUtils.move(sourcePath, destPath);
+    await movePath(sourcePath, destPath);
   } catch (e) {
     ztoolkit.log(e);
     return await moveFile(attItem);
@@ -909,7 +911,7 @@ export async function moveFile(attItem: any) {
   json.linkMode = "linked_file";
   json.path = destPath;
   delete json.filename;
-  const newAttItem = new Zotero.Item("attachment");
+  const newAttItem = new Zotero.Item("attachment" as any);
   newAttItem.libraryID = attItem.libraryID;
   newAttItem.fromJSON(json);
   await newAttItem.saveTx();
@@ -1219,7 +1221,7 @@ async function addSuffixToFilename(filename: string, suffix?: string) {
     destPath = destName; // 假设 destPath 是目标文件路径
 
     // 检查文件是否存在
-    if (await IOUtils.exists(destPath)) {
+    if (await pathExists(destPath)) {
       incr++;
     } else {
       return destPath;
@@ -1229,7 +1231,7 @@ async function addSuffixToFilename(filename: string, suffix?: string) {
 
 async function checkDir(prefName: string, prefDisplay: string) {
   let dir = getPref(prefName);
-  if (typeof dir !== "string" || !(await IOUtils.exists(dir))) {
+  if (typeof dir !== "string" || !(await pathExists(dir, "directory"))) {
     // @ts-ignore window
     const fp = new window.FilePicker();
 
@@ -1251,6 +1253,68 @@ async function checkDir(prefName: string, prefDisplay: string) {
     }
   }
   return dir;
+}
+
+type PathKind = "file" | "directory";
+
+async function pathExists(path: string, kind?: PathKind) {
+  try {
+    if (await IOUtils.exists(path)) {
+      if (!kind) {
+        return true;
+      }
+      return pathMatchesKind(path, kind);
+    }
+  } catch (e) {
+    ztoolkit.log("IOUtils.exists failed", path, e);
+  }
+
+  try {
+    const file = Zotero.File.pathToFile(path) as any;
+    const exists = file.exists();
+    const isDirectory = getNsIFileKind(file, "directory");
+    const isFile = getNsIFileKind(file, "file");
+    if (!kind) {
+      return exists || isDirectory || isFile;
+    }
+    // Some Windows mount-point roots report exists() as false while
+    // isDirectory() still correctly identifies the target as a directory.
+    return kind === "directory" ? isDirectory : isFile;
+  } catch (e) {
+    ztoolkit.log("nsIFile exists fallback failed", path, e);
+    return false;
+  }
+}
+
+function pathMatchesKind(path: string, kind: PathKind) {
+  try {
+    const file = Zotero.File.pathToFile(path) as any;
+    return kind === "directory" ? file.isDirectory() : file.isFile();
+  } catch (e) {
+    ztoolkit.log("nsIFile type check failed", path, e);
+    return false;
+  }
+}
+
+async function movePath(sourcePath: string, destPath: string) {
+  try {
+    await IOUtils.move(sourcePath, destPath);
+    return;
+  } catch (e) {
+    ztoolkit.log("IOUtils.move failed; retrying with nsIFile.moveTo", e);
+  }
+
+  const sourceFile = Zotero.File.pathToFile(sourcePath) as any;
+  const destFile = Zotero.File.pathToFile(destPath) as any;
+  sourceFile.moveTo(destFile.parent, destFile.leafName);
+}
+
+function getNsIFileKind(file: any, kind: PathKind) {
+  try {
+    return kind === "directory" ? file.isDirectory() : file.isFile();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -886,18 +886,8 @@ export async function moveFile(attItem: any) {
     }
   }
   // 创建中间路径
-  if (!(await pathExists(destDir, "directory"))) {
-    const create = [destDir];
-    let parent = PathUtils.parent(destDir);
-    while (parent && !(await pathExists(parent, "directory"))) {
-      create.push(parent);
-      parent = PathUtils.parent(parent);
-    }
-    await Promise.all(
-      create
-        .reverse()
-        .map(async (f) => await Zotero.File.createDirectoryIfMissingAsync(f)),
-    );
+  if (!(await createDirectoryPath(destDir))) {
+    return;
   }
   // await Zotero.File.createDirectoryIfMissingAsync(destDir);
   // 移动文件到目标文件夹
@@ -1315,6 +1305,40 @@ function getNsIFileKind(file: any, kind: PathKind) {
   } catch {
     return false;
   }
+}
+
+async function createDirectoryPath(destDir: string) {
+  if (await pathExists(destDir, "directory")) {
+    return true;
+  }
+
+  const create: string[] = [];
+  let current: string | null = destDir;
+  while (current && !(await pathExists(current, "directory"))) {
+    if (await pathExists(current, "file")) {
+      showPathConflict(current);
+      return false;
+    }
+    create.push(current);
+    current = PathUtils.parent(current) as string | null;
+  }
+
+  await Promise.all(
+    create
+      .reverse()
+      .map(async (f) => await Zotero.File.createDirectoryIfMissingAsync(f)),
+  );
+  return true;
+}
+
+function showPathConflict(path: string) {
+  ztoolkit.log("Cannot create directory because a file already exists", path);
+  new ztoolkit.ProgressWindow(config.addonName)
+    .createLine({
+      text: `Cannot create directory because a file already exists: ${path}`,
+      type: "default",
+    })
+    .show();
 }
 
 /**

--- a/src/utils/shortcut.ts
+++ b/src/utils/shortcut.ts
@@ -30,7 +30,7 @@ export function listenShortcut(inputNode: HTMLInputElement, callback: (shortcut:
     ) {
       shortcut.key = e.key.toUpperCase();
     }
-    let keys = []
+    let keys: string[] = []
     if (shortcut.control) {
       keys.push("Ctrl")
     }


### PR DESCRIPTION
Fixes #232

## Summary

- Add a path existence helper that checks `IOUtils.exists()` first and falls back to `nsIFile` kind checks.
- Treat Windows mount-point directory roots as valid when `nsIFile.exists()` reports false but `nsIFile.isDirectory()` returns true.
- Use the helper in `checkDir()`, destination collision checks, suffix generation, and destination directory creation.
- Add a fallback from `IOUtils.move()` to `nsIFile.moveTo()` for virtual file systems where `IOUtils.move()` may fail.

## Context

With a CloudDrive-mounted target directory on Windows, the target root can be an NTFS mount-point/junction (`IO_REPARSE_TAG_MOUNT_POINT`). During debugging, the mount root behaved like this in Zotero/Firefox file APIs:

```text
IOUtils.exists(targetRoot) -> false
nsIFile.exists() -> false
nsIFile.isDirectory() -> true
```

Subdirectories under the target root remained accessible, and moving files into them worked. Because `checkDir()` only trusted `IOUtils.exists()`, Attanger treated the saved target directory as missing and opened the folder picker every time.

This change keeps the existing `IOUtils.exists()` fast path, but accepts `nsIFile.isDirectory()` as a directory-specific fallback for Windows mount-point roots.

## Environment

Originally reported with:

- Windows 11 24H2
- Zotero 7.0.13 64-bit
- Attanger 1.3.1
- CloudDrive 0.8.11

Verified locally with:

- Zotero 7.0.32
- Windows 25H2, build 26200
- CloudDrive 1.0.6 Build 26-04-16 02:06:17
- Attanger built from this branch

## Testing

- Built the add-on with `npm run build`.
- Installed a debug XPI in Zotero and reproduced the repeated directory picker.
- Confirmed the target root reports `exists() === false` but `isDirectory() === true`.
- Installed the final XPI without debug logging and verified adding a new attachment no longer opens the target directory picker, and the file is moved into the configured target subfolder.