### PR TITLE
根据复制/移动附件的模式实时更新附件右键菜单文案

### DIFF
--- a/addon/locale/de/addon.ftl
+++ b/addon/locale/de/addon.ftl
@@ -1,9 +1,12 @@
 attachment-manager = Anhang-Manager
 attach-new-file = Neue Datei anhängen
 rename-move-attachment = Anhang umbenennen und verschieben
+rename-copy-attachment = Anhang umbenennen und kopieren
 match-attachment = Anhang zuordnen
 rename-attachment = Anhang umbenennen
 move-attachment = Anhang verschieben
+copy-attachment = Anhang kopieren
+undo-copy-attachment = Anhangkopie rueckgaengig machen
 restore-pdf-annotation = PDF-Anmerkung wiederherstellen
 open-using = Öffnen mit
 choose-other-app = Andere App auswählen

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -1,11 +1,14 @@
 attachment-manager = Attachment Manager
 attach-new-file = Attach New File
 rename-move-attachment = Rename and Move Attachment
+rename-copy-attachment = Rename and Copy Attachment
 match-attachment = Match Attachment
 match-attanger-attachment = Match Attanger Attachment
 rename-attachment = Rename Attachment
 move-attachment = Move Attachment
+copy-attachment = Copy Attachment
 undo-move-attachment = Undo Move Attachment
+undo-copy-attachment = Undo Copy Attachment
 restore-pdf-annotation = Restore PDF Annotation
 open-using = Open Using
 choose-other-app = Choose Other App

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -1,10 +1,13 @@
 attachment-manager = Attachment Manager
 attach-new-file = Allega nuovo file
 rename-move-attachment = Rinomina e sposta allegato
+rename-copy-attachment = Rinomina e copia allegato
 match-attachment = Abbina allegato
 rename-attachment = Rinomina allegato
 move-attachment = Sposta allegato
+copy-attachment = Copia allegato
 undo-move-attachment = Annulla lo spostamento allegato
+undo-copy-attachment = Annulla la copia allegato
 restore-pdf-annotation = Ripristina annotazione PDF
 open-using = Apri con
 choose-other-app = Scegli altra app

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -1,11 +1,14 @@
 attachment-manager = 附件管理
 attach-new-file = 附加新文件
 rename-move-attachment = 重命名并移动附件
+rename-copy-attachment = 重命名并复制附件
 match-attachment = 匹配附件
 match-attanger-attachment = 匹配Attanger附件
 rename-attachment = 重命名附件
 move-attachment = 移动附件
+copy-attachment = 复制附件
 undo-move-attachment = 撤销移动附件
+undo-copy-attachment = 撤销复制附件
 restore-pdf-annotation = 恢复PDF标注
 open-using = 打开方式
 choose-other-app = 选择其它应用

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/muisedestiny/zotero-attanger#readme",
   "dependencies": {
     "string-comparison": "^1.3.0",
-    "zotero-plugin-toolkit": "^5.0.1"
+    "zotero-plugin-toolkit": "5.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -18,6 +18,9 @@ class Addon {
       // columns: Array<ColumnOptions>;
       // rows: Array<{ [dataKey: string]: string }>;
     };
+    menu?: {
+      refreshItemMenu: () => void;
+    };
     dialog?: DialogHelper;
     icons: { [name: string]: string };
     folderSep: string;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -26,7 +26,7 @@ async function onStartup() {
 
 async function onMainWindowLoad(win: Window): Promise<void> {
   addon.data.ztoolkit = createZToolkit();
-  new Menu();
+  addon.data.menu = new Menu();
 }
 
 async function onMainWindowUnload(win: Window): Promise<void> {

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -7,6 +7,10 @@ import comparison from "string-comparison";
 import { registerShortcut } from "../utils/shortcut";
 
 const filenameExtRE = /\.[^.]+$/;
+const ATTANGER_MENU_ID = "attanger-menu";
+const RENAME_MOVE_MENU_ID = "attanger-rename-move-attachment";
+const MOVE_MENU_ID = "attanger-move-attachment";
+const UNDO_MOVE_MENU_ID = "attanger-undo-move-attachment";
 
 /**
  * 避免因为选中A操作移动，移动过程中点击了B分类
@@ -14,6 +18,7 @@ const filenameExtRE = /\.[^.]+$/;
 let selectedCollection: Zotero.Collection | undefined
 export default class Menu {
   constructor() {
+    addon.data.menu = this;
     registerNotify(["item"],
       async (event: _ZoteroTypes.Notifier.Event, type: _ZoteroTypes.Notifier.Type, ids: string[] | number[], extraData: _ZoteroTypes.anyObj) => {
         ztoolkit.log(event, type, extraData);
@@ -88,10 +93,50 @@ export default class Menu {
     }
   }
 
+  private getMoveMenuStringKey(moveKey: string, copyKey: string) {
+    return getPref("moveWithoutDeleting") ? copyKey : moveKey;
+  }
+
+  public refreshItemMenu() {
+    for (const win of Zotero.getMainWindows()) {
+      win.document.getElementById(RENAME_MOVE_MENU_ID)?.setAttribute(
+        "label",
+        getString(
+          this.getMoveMenuStringKey(
+            "rename-move-attachment",
+            "rename-copy-attachment",
+          ),
+        ),
+      );
+      win.document.getElementById(MOVE_MENU_ID)?.setAttribute(
+        "label",
+        getString(this.getMoveMenuStringKey("move-attachment", "copy-attachment")),
+      );
+      win.document.getElementById(UNDO_MOVE_MENU_ID)?.setAttribute(
+        "label",
+        getString(
+          this.getMoveMenuStringKey(
+            "undo-move-attachment",
+            "undo-copy-attachment",
+          ),
+        ),
+      );
+    }
+  }
+
   private register() {
+    const attachNewFileCallback = async () => {
+      const item = ZoteroPane.getSelectedItems()[0];
+      await attachNewFile({
+        libraryID: item.libraryID,
+        parentItemID: item.id,
+        collections: undefined,
+      });
+    };
+
     ztoolkit.Menu.register("item", {
       tag: "menu",
-      id: "attanger-menu",
+      id: ATTANGER_MENU_ID,
       label: "Attanger",
       icon: addon.data.icons.favicon,
       children: [
@@ -116,7 +161,13 @@ export default class Menu {
         // 重命名并移动
         {
           tag: "menuitem",
-          label: getString("rename-move-attachment"),
+          id: RENAME_MOVE_MENU_ID,
+          label: getString(
+            this.getMoveMenuStringKey(
+              "rename-move-attachment",
+              "rename-copy-attachment",
+            ),
+          ),
           icon: addon.data.icons.renameMoveAttachment,
           commandListener: async (_ev) => {
             selectedCollection = ZoteroPane.getSelectedCollection()
@@ -202,7 +253,10 @@ export default class Menu {
         },
         {
           tag: "menuitem",
-          label: getString("move-attachment"),
+          id: MOVE_MENU_ID,
+          label: getString(
+            this.getMoveMenuStringKey("move-attachment", "copy-attachment"),
+          ),
           icon: addon.data.icons.moveFile,
           commandListener: async (_ev) => {
             selectedCollection = ZoteroPane.getSelectedCollection()
@@ -218,7 +272,13 @@ export default class Menu {
         },
         {
           tag: "menuitem",
-          label: getString("undo-move-attachment"),
+          id: UNDO_MOVE_MENU_ID,
+          label: getString(
+            this.getMoveMenuStringKey(
+              "undo-move-attachment",
+              "undo-copy-attachment",
+            ),
+          ),
           icon: addon.data.icons.undoMoveFile,
           commandListener: async () => {
             await ZoteroPane.convertLinkedFilesToStoredFiles();
@@ -264,16 +324,6 @@ export default class Menu {
     //     await matchAttangerAttachment();
     //   },
     // });
-    // 附加新文件
-    //   条目
-    const attachNewFileCallback = async () => {
-      const item = ZoteroPane.getSelectedItems()[0];
-      await attachNewFile({
-        libraryID: item.libraryID,
-        parentItemID: item.id,
-        collections: undefined,
-      });
-    };
     // ztoolkit.Menu.register("item", {
     //   tag: "menuitem",
     //   label: getString("attach-new-file"),
@@ -311,6 +361,7 @@ export default class Menu {
         });
       },
     });
+    this.refreshItemMenu();
     // 附件管理
     // ztoolkit.Menu.register("item", {
     //   tag: "menu",

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -82,6 +82,11 @@ function bindPrefEvents(_window: Window) {
   doc.querySelector("#attach-type")?.addEventListener("command", async () => {
     await updatePrefsUI();
   });
+  doc
+    .querySelector('[preference$=".moveWithoutDeleting"]')
+    ?.addEventListener("command", () => {
+      addon.data.menu?.refreshItemMenu();
+    });
 
   doc
     .querySelectorAll(".shortcut")


### PR DESCRIPTION
## 概要

这个 PR 让 Attanger 在启用“保留原始文件，不删除源文件（移动/匹配/附加均生效）”后，右键菜单中的相关文案能够随之切换为“复制”语义；关闭该选项时则保持“移动”语义。

## 改动内容

- 根据 `moveWithoutDeleting` 偏好动态更新以下 3 个条目右键菜单项文案：
  - `重命名并移动附件` -> `重命名并复制附件`
  - `移动附件` -> `复制附件`
  - `撤销移动附件` -> `撤销复制附件`
- 在设置页切换该选项后，立即刷新菜单文案
- 为以下语言补充对应的本地化文案：
  - `en-US`
  - `zh-CN`
  - `de`
  - `it-IT`
- 将 `zotero-plugin-toolkit` 固定为 `5.0.1`，避免依赖漂移导致当前版本菜单 API 失效

## 说明

- 这个 PR 只调整菜单文案显示，不改变原有移动/复制处理逻辑
- 菜单文案会在下次打开右键菜单时体现最新状态