### PR TITLE
feat: port zotfile diacritics filename cleanup

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -214,6 +214,8 @@
         preference="extensions.zotero.__addonRef__.moveWithoutDeleting" />
       <checkbox native="true" data-l10n-id="sync-attachment-title"
         preference="extensions.zotero.__addonRef__.syncAttachmentTitle" />
+      <checkbox native="true" data-l10n-id="remove-diacritics"
+        preference="extensions.zotero.__addonRef__.removeDiacritics" />
       <hbox align="center">
         <label data-l10n-id="file-types"></label>
         <html:input type="text" flex="1" preference="extensions.zotero.__addonRef__.fileTypes">

--- a/addon/locale/de/preferences.ftl
+++ b/addon/locale/de/preferences.ftl
@@ -82,3 +82,5 @@ move-attachment-shortcut =
     .label = Shortcut for Move/Copy Attachment
 sync-attachment-title = 
     .label = Anhangtitel nach Umbenennung synchronisieren
+remove-diacritics =
+    .label = Sonderzeichen (Diakritika) aus Dateinamen entfernen

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -83,3 +83,5 @@ move-attachment-shortcut =
     .label = Shortcut for Move/Copy Attachment
 sync-attachment-title = 
     .label = Sync attachment title after renaming
+remove-diacritics =
+    .label = Remove special characters (diacritics) from filename

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -82,3 +82,5 @@ move-attachment-shortcut =
     .label = Shortcut for Move/Copy Attachment
 sync-attachment-title = 
     .label = Sincronizza il titolo dell'allegato dopo la rinominazione
+remove-diacritics =
+    .label = Rimuovi i caratteri speciali (diacritici) dal nome file

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -82,3 +82,5 @@ move-attachment-shortcut =
     .label = 移动/复制附件快捷键
 sync-attachment-title = 
     .label = 重命名后同步修改附件标题
+remove-diacritics =
+    .label = 从文件名中移除特殊字符（重音符号）

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -54,3 +54,4 @@ pref("extensions.zotero.__addonRef__.autoRemoveEmptyFolder", false);
 
 pref("extensions.zotero.__addonRef__.moveWithoutDeleting", false);
 pref("extensions.zotero.__addonRef__.syncAttachmentTitle", false);
+pref("extensions.zotero.__addonRef__.removeDiacritics", false);

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -1238,6 +1238,7 @@ async function renameFileInternal(attItem: Zotero.Item, retry = 0) {
   let newName = Zotero.Attachments.getFileBaseNameFromItem(parentItem, {
     attachmentTitle: attItem.getField("title") as string,
   } as any);
+  newName = removeFilenameDiacritics(newName);
 
   const ext = origFilename.match(filenameExtRE);
   if (ext) {
@@ -1302,6 +1303,17 @@ function shouldSyncAttachmentTitle(
     return true;
   }
   return title === "PDF" && attItem.attachmentContentType === "application/pdf";
+}
+
+function removeFilenameDiacritics(filename: string) {
+  if (!getPref("removeDiacritics")) return filename;
+  const utilities = Zotero.Utilities as {
+    removeDiacritics?: (value: string) => string;
+  };
+  if (typeof utilities.removeDiacritics !== "function") {
+    return filename;
+  }
+  return utilities.removeDiacritics(filename);
 }
 
 /**

--- a/tests/attachmentAutomation.test.cjs
+++ b/tests/attachmentAutomation.test.cjs
@@ -154,6 +154,31 @@ test("invalid filename rules are logged and do not abort modify renaming", async
   menu.dispose();
 });
 
+test("removeDiacritics converts base names before renaming", async () => {
+  harness = createHarness({
+    baseName: "résumé étude",
+    prefs: {
+      autoRenameOnModify: true,
+      autoRenameOnModifyDebounceMs: 0,
+      removeDiacritics: true,
+    },
+  });
+  const parent = createRegularItem(harness, { id: 32 });
+  const attachment = createAttachment(harness, {
+    id: 33,
+    mode: "linked",
+    parent,
+    path: "/library/old.pdf",
+  });
+  const menu = new harness.module.default();
+
+  await harness.notify("modify", [parent.id]);
+  await harness.clock.runAll();
+
+  assert.deepEqual(attachment.calls.rename, ["resume etude.pdf"]);
+  menu.dispose();
+});
+
 test("add processing deduplicates a parent and its directly-notified attachment", async () => {
   harness = createHarness();
   const parent = createRegularItem(harness, { id: 40 });

--- a/tests/helpers/menuHarness.cjs
+++ b/tests/helpers/menuHarness.cjs
@@ -104,6 +104,7 @@ function createHarness(options = {}) {
     filenameAsPrefixRules: "",
     filenameSkipAutoMoveRenameRules: "",
     filenameSkipRenameRules: "",
+    removeDiacritics: false,
     moveWithoutDeleting: false,
     readPDFtitle: "nonCJK",
     sourceDir: "/source",
@@ -434,6 +435,8 @@ function createHarness(options = {}) {
         md5: (file) =>
           options.md5 ? options.md5(file.path) : `md5:${file.path}`,
       },
+      removeDiacritics: (value) =>
+        value.normalize("NFD").replace(/[\u0300-\u036f]/g, ""),
     },
     getMainWindows: () => [],
     getStorageDirectory: () => ({ path: "/storage" }),

--- a/tests/projectSurface.test.cjs
+++ b/tests/projectSurface.test.cjs
@@ -21,6 +21,7 @@ test("auto-rename preferences have defaults and checkbox controls", () => {
   assert.match(prefs, /autoRenameOnModifyDebounceMs", 1000/);
   assert.match(prefs, /autoRenameOnModifyDelayEnabled", false/);
   assert.match(prefs, /autoRenameOnModifyDelayMs", 0/);
+  assert.match(prefs, /removeDiacritics", false/);
   assert.match(preferences, /id="auto-rename-on-modify"/);
   assert.match(
     preferences,
@@ -68,6 +69,7 @@ test("new automation locale keys exist in all supported locales", () => {
     "auto-rename-on-modify",
     "auto-rename-on-modify-debounce",
     "auto-rename-on-modify-delay",
+    "remove-diacritics",
   ];
   const helpKeys = [
     "auto-rename-on-modify-help",


### PR DESCRIPTION
Zotfile has a "Remove special characters (diacritics) from filename" option that strips accented characters (e.g. `é` -> `e`, `ü` -> `u`) before writing a renamed attachment to disk. Attanger had no equivalent, so filenames from items with accented titles or author names would retain those characters even on systems that handle them poorly.

## What this does

- Adds a new boolean preference `removeDiacritics` (default `false`).
- After `getFileBaseNameFromItem` produces a candidate filename, `removeFilenameDiacritics()` is called when the preference is on. It delegates to `Zotero.Utilities.removeDiacritics()`, which is the same API Zotfile used.
- A graceful no-op is returned if the runtime does not expose that utility method.
- A checkbox appears in the "Other Settings" section of Attanger's preferences pane.

## Localization

All four supported locales are updated:

| Locale | Label |
|--------|-------|
| en-US | Remove special characters (diacritics) from filename |
| zh-CN | 从文件名中移除特殊字符（重音符号） |
| de | Sonderzeichen (Diakritika) aus Dateinamen entfernen |
| it-IT | Rimuovi i caratteri speciali (diacritici) dal nome file |

## Tests

- `menuHarness.cjs`: added `removeDiacritics: false` to default prefs and a `Zotero.Utilities.removeDiacritics` stub using NFD normalization.
- `attachmentAutomation.test.cjs`: new test verifies `resume etude.pdf` is produced when the base name is `résumé étude`.
- `projectSurface.test.cjs`: asserts the pref default exists and the locale key is present in all locales.

All 23 tests pass.