### PR TITLE
Fix selected collection handling on Zotero 10

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -33,6 +33,16 @@ function getShortcutHint(shortcutPref: string) {
  */
 let selectedCollection: Zotero.Collection | undefined;
 
+function getSelectedCollectionCompat() {
+  const pane = ZoteroPane as typeof ZoteroPane & {
+    getSelectedCollections?: () => Zotero.Collection[];
+  };
+  if (pane.getSelectedCollections) {
+    return pane.getSelectedCollections()[0];
+  }
+  return pane.getSelectedCollection() as Zotero.Collection | undefined;
+}
+
 /** 正在被 moveFile 处理的源文件路径集合，防止并发重复调用 */
 const movingPaths = new Set<string>();
 /** Attanger 正在修改的附件，避免自身 saveTx 再次触发自动重命名 */
@@ -437,7 +447,7 @@ export default class Menu {
     };
 
     const renameMoveAttachmentCallback = async () => {
-      selectedCollection = ZoteroPane.getSelectedCollection();
+      selectedCollection = getSelectedCollectionCompat();
       const attachmentItems = getAttachmentItems(false);
       if (!attachmentItems.length) {
         showMoveMessage("No attachment selected.");
@@ -487,7 +497,7 @@ export default class Menu {
     };
 
     const moveAttachmentCallback = async () => {
-      selectedCollection = ZoteroPane.getSelectedCollection();
+      selectedCollection = getSelectedCollectionCompat();
       for (const item of getAttachmentItems(false)) {
         try {
           const attItem = await moveFile(item);
@@ -689,8 +699,8 @@ export default class Menu {
         return ZoteroPane.getCollectionTreeRow()?.isCollection();
       },
       commandListener: async (_ev) => {
-        const collection =
-          ZoteroPane.getSelectedCollection() as Zotero.Collection;
+        const collection = getSelectedCollectionCompat();
+        if (!collection) return;
         await attachNewFile({
           libraryID: collection.libraryID,
           parentItemID: undefined,
@@ -1764,7 +1774,7 @@ function showAttachmentItem(attItem: Zotero.Item) {
   if (attItem && attItem.isTopLevelItem()) {
     popupWin
       .createLine({
-        text: (ZoteroPane.getSelectedCollection() as Zotero.Collection).name,
+        text: getSelectedCollectionCompat()?.name || "My Library",
         icon: addon.data.icons.collection,
       })
       .show();

--- a/tests/attachmentAutomation.test.cjs
+++ b/tests/attachmentAutomation.test.cjs
@@ -549,6 +549,42 @@ test("an exact existing linked destination is reused without creating another it
   assert.equal(harness.calls.newItems.length, 0);
 });
 
+test("manual move uses the plural collection API when the singular API was removed", async () => {
+  harness = createHarness({
+    directories: ["/source", "/dest"],
+    files: ["/source/paper.pdf"],
+    prefs: { destDir: "/dest", subfolderFormat: "" },
+  });
+  const parent = createRegularItem(harness, { id: 93 });
+  const attachment = createAttachment(harness, {
+    id: 94,
+    mode: "imported",
+    parent,
+    path: "/source/paper.pdf",
+  });
+  harness.selectedItems = [attachment];
+  harness.selectedCollection = { id: 12, name: "Research" };
+  global.ZoteroPane.getSelectedCollections = () => [harness.selectedCollection];
+  global.ZoteroPane.getSelectedCollection = () => {
+    throw new Error(
+      "ZoteroPane.getSelectedCollection() was removed -- use ZoteroPane.getSelectedCollections()",
+    );
+  };
+  const menu = new harness.module.default();
+  const rootMenu = harness.menuRegistrations.find(
+    ({ type, config }) => type === "item" && config.id === "attanger-menu",
+  ).config;
+  const moveAttachment = rootMenu.children.find(
+    (child) => child.id === "attanger-move-attachment",
+  );
+
+  await moveAttachment.commandListener();
+
+  assert.equal(harness.calls.newItems.length, 1);
+  assert.equal(attachment.calls.erase, 1);
+  menu.dispose();
+});
+
 test("Match Attanger Attachment creates links instead of imported copies", async () => {
   harness = createHarness({
     baseName: "Expected",


### PR DESCRIPTION
## Summary

- use `getSelectedCollections()[0]` on Zotero versions that provide the plural API
- retain the singular accessor fallback for Zotero 7
- avoid dereferencing a missing collection when operating from My Library
- add a regression test that reproduces Zotero 10's removed-API error

## Reproduction

On Zotero 10, choosing Attanger's Move Attachment or Rename and Move action throws:

`ZoteroPane.getSelectedCollection() was removed -- use ZoteroPane.getSelectedCollections()`

This prevents linked-file conversion from running.

## Verification

- `npm test` — 24/24 passed
- `npm run build`
- `npx eslint src/modules/menu.ts`
- `npx prettier --check src/modules/menu.ts tests/attachmentAutomation.test.cjs`

Tested manually on Zotero 10. The patch was AI-assisted and reviewed; no private library data or local paths are included.